### PR TITLE
add Docker image for C SDK builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This project contains build scripts for Docker images used by LaunchDarkly SDK CI builds. These Dockerfiles are publicly accessible because they're referenced in the CircleCI configuration files within each open-source SDK repository.
 
 Docker images in this repository include:
+* [`ld-c-sdk-ubuntu`](./ld-c-sdk-ubuntu)
 * [`ld-xamarin-android-linux`](./ld-xamarin-android-linux)
 
 ## Development instructions 
@@ -10,5 +11,9 @@ Docker images in this repository include:
 To build and publish an image:
 
 * Make sure the version number at the top of the Dockerfile has been updated if necessary.
-* `make login`
+* `make login` (provide the credentials for `ldcircleci`)
 * `make push-latest`
+
+## Reporting problems or suggestions
+
+Since these images are really part of the build for the SDK projects, please do not submit issues or PRs on this repository; instead, submit them on whatever SDK repository is or would be affected by the problem or suggestion.

--- a/base.mk
+++ b/base.mk
@@ -1,0 +1,21 @@
+
+DOCKER_TAG=$(DOCKER_TAG_BASE):$(VERSION)
+DOCKER_TAG_LATEST=$(DOCKER_TAG_BASE):latest
+
+push-latest: push
+	docker tag $(DOCKER_TAG) $(DOCKER_TAG_LATEST)
+	docker push $(DOCKER_TAG_LATEST)
+
+push: build login
+	docker push $(DOCKER_TAG)
+
+build:
+	docker build -t $(DOCKER_TAG) .
+
+echo-tag:
+	echo "$(DOCKER_TAG)"
+
+login:
+	docker login
+
+.PHONY: build echo-tag login push push-latest

--- a/ld-c-sdk-ubuntu/Dockerfile
+++ b/ld-c-sdk-ubuntu/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:18.10
+
+WORKDIR /home/circleci
+
+# Basic C SDK dependencies: libcurl4-openssl-dev 
+# Server-side C SDK dependencies: libpcre3-dev
+# Make-based build: build-essential
+# Cmake-based build: cmake
+# Documentation build: doxygen zip
+
+RUN apt-get update -y && apt-get install -y \
+  libcurl4-openssl-dev \
+  libpcre3-dev \
+  build-essential \
+  cmake \
+  doxygen zip

--- a/ld-c-sdk-ubuntu/Makefile
+++ b/ld-c-sdk-ubuntu/Makefile
@@ -2,6 +2,6 @@
 # This version should be incremented with every material change
 VERSION=1
 
-DOCKER_TAG_BASE="ldcircleci/ld-xamarin-android-linux"
+DOCKER_TAG_BASE="ldcircleci/ld-c-sdk-ubuntu"
 
 include ../base.mk

--- a/ld-c-sdk-ubuntu/README.md
+++ b/ld-c-sdk-ubuntu/README.md
@@ -1,0 +1,3 @@
+# ldcircleci/ld-c-sdk-ubuntu
+
+This image is based on a standard CircleCI Linux image, and adds the packages that are needed to build the LaunchDarkly C/C++ SDKs for Linux. It should not be used in other projects since its requirements are tied to the C/C++ SDK builds.


### PR DESCRIPTION
This combines the package dependencies for c-client-sdk and c-server-sdk, to speed up our builds.

I've already published the image and tested it on branches of both: https://circleci.com/gh/launchdarkly/c-client-sdk-private/1360 https://circleci.com/gh/launchdarkly/c-server-sdk-private/1210