### PR TITLE
add image for PHP SDK releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+ld-php-sdk-release/downloads
 ld-xamarin-android-linux/downloads

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This project contains build scripts for Docker images used by LaunchDarkly SDK C
 
 Docker images in this repository include:
 * [`ld-c-sdk-ubuntu`](./ld-c-sdk-ubuntu)
+* [`ld-php-sdk-release`](./ld-php-sdk-release)
 * [`ld-xamarin-android-linux`](./ld-xamarin-android-linux)
 
 ## Development instructions 

--- a/base.mk
+++ b/base.mk
@@ -5,6 +5,10 @@
 DOCKER_TAG=$(DOCKER_TAG_BASE):$(VERSION)
 DOCKER_TAG_LATEST=$(DOCKER_TAG_BASE):latest
 
+# If applicable, set LOCAL_DEPENDENCIES in the individual project's Makefile to the paths of any
+# content that must be built locally by the Makefile before running Docker
+# LOCAL_DEPENDENCIES=my-downloaded-file.zip
+
 push-latest: push
 	docker tag $(DOCKER_TAG) $(DOCKER_TAG_LATEST)
 	docker push $(DOCKER_TAG_LATEST)
@@ -12,7 +16,7 @@ push-latest: push
 push: build login
 	docker push $(DOCKER_TAG)
 
-build:
+build: $(LOCAL_DEPENDENCIES)
 	docker build -t $(DOCKER_TAG) .
 
 echo-tag:

--- a/ld-php-sdk-release/Dockerfile
+++ b/ld-php-sdk-release/Dockerfile
@@ -1,0 +1,12 @@
+FROM circleci/php:7.2
+# phpDocumentor requires PHP >= 7.2
+
+WORKDIR /home/circleci
+
+ENV PHPDOCUMENTOR_ARCHIVE_FILE=phpDocumentor.phar
+
+ENV LDTOOLS_DIR=/home/circleci/ldtools
+
+RUN mkdir -p ${LDTOOLS_DIR}
+
+ADD downloads/${PHPDOCUMENTOR_ARCHIVE_FILE} ${LDTOOLS_DIR}

--- a/ld-php-sdk-release/Makefile
+++ b/ld-php-sdk-release/Makefile
@@ -1,0 +1,24 @@
+
+# This version should be incremented with every material change
+VERSION=1
+
+DOCKER_TAG_BASE="ldcircleci/ld-php-sdk-release"
+
+# This is a temporary download URL from the phpDocumentor project's CI - once there's a stable
+# build of phpDocumentor 3, this will be replaced by a stable download URL.
+#
+# Note that the GitHub API for downloading CI artifacts does not support authentication by SSH
+# key. Therefore, this script will ask you interactively for your GitHub credentials.
+PHPDOCUMENTOR_DOWNLOAD_URL=https://api.github.com/repos/phpDocumentor/phpDocumentor/actions/artifacts/1690972/zip
+
+PHPDOCUMENTOR_ARCHIVE_FILE=phpDocumentor.phar
+
+LOCAL_DEPENDENCIES=$(shell pwd)/downloads/$(PHPDOCUMENTOR_ARCHIVE_FILE)
+DOWNLOADED_ARCHIVE=$(shell pwd)/downloads/phpDocumentor.phar.zip
+
+include ../base.mk
+
+$(LOCAL_DEPENDENCIES):
+	@mkdir -p downloads
+	@echo "GitHub username for download:" && read gituser && curl --fail -L -u $$gituser -v $(PHPDOCUMENTOR_DOWNLOAD_URL) > $(DOWNLOADED_ARCHIVE)
+	@cd downloads && unzip $(DOWNLOADED_ARCHIVE)

--- a/ld-php-sdk-release/README.md
+++ b/ld-php-sdk-release/README.md
@@ -1,0 +1,5 @@
+# ldcircleci/ld-php-sdk-release
+
+This Ubuntu image contains the PHP tools that are used in releasing the LaunchDarkly PHP SDK.
+
+It preinstalls `phpDocumentor.phar` under `/home/circleci/ldtools`.


### PR DESCRIPTION
This will let us avoid checking the phpDocumentor tool into source control for [this PR](https://github.com/launchdarkly/php-server-sdk-private/pull/50).