### PR TITLE
[ch67029] c image use ubuntu 18.04

### DIFF
--- a/ld-c-sdk-ubuntu/Dockerfile
+++ b/ld-c-sdk-ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:18.04
 
 WORKDIR /home/circleci
 


### PR DESCRIPTION
It uses 18.10 right now which is no longer supported, and I would rather use an LTS anyways