### PR TITLE
add release image for .NET

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This project contains build scripts for Docker images used by LaunchDarkly SDK C
 Despite the `ldcircleci/` prefix, these images could also be used in release processes that do not use a CI host.
 
 Docker images in this repository include:
+* [`ldcircleci/dotnet5-release`](./dotnet5-release)
 * [`ldcircleci/ld-c-sdk-ubuntu`](./ld-c-sdk-ubuntu)
 * [`ldcircleci/ld-xamarin-android-linux`](./ld-xamarin-android-linux)
 * [`ldcircleci/php-sdk-release`](./php-sdk-release)

--- a/dotnet5-release/Dockerfile
+++ b/dotnet5-release/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:20.04 as builder
+
+# Install prerequisites for osssigncode
+RUN apt-get -q update
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+	build-essential pkg-config libssl-dev libcurl4-openssl-dev
+
+# Build osssigncode (source distribution already downloaded and unzipped by Makefile)
+COPY ./downloads/signcode /root/buildsigncode
+RUN cd /root/buildsigncode && cd $(ls) && ./configure && make && cp osslsigncode /root
+
+
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal
+
+# Install Mono - see https://www.mono-project.com/download/stable
+RUN apt-get update
+RUN apt-get install -y gnupg ca-certificates
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+RUN echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | tee /etc/apt/sources.list.d/mono-official-stable.list
+RUN apt-get update
+RUN apt-get install -y mono-devel
+
+# Copy docfx (already downloaded and unzipped by Makefile)
+COPY ./downloads/docfx /root/docfx
+ENV PATH="${PATH}:/root/docfx"
+
+# Copy osslsigncode which we built in the previous image
+RUN mkdir /root/signcode
+COPY --from=builder /root/osslsigncode /root/signcode/
+ENV PATH="${PATH}:/root/signcode"

--- a/dotnet5-release/Makefile
+++ b/dotnet5-release/Makefile
@@ -1,0 +1,44 @@
+
+# This version should be incremented with every material change
+VERSION=1
+
+DOCKER_TAG_BASE="ldcircleci/dotnet5-release"
+
+DOCFX_VERSION_TAG=v2.57.2
+DOCFX_DOWNLOAD_URL=https://github.com/dotnet/docfx/releases/download/$(DOCFX_VERSION_TAG)/docfx.zip
+
+SIGNCODE_DOWNLOAD_URL=https://github.com/mtrojnar/osslsigncode/releases/download/2.1/osslsigncode-2.1.0.tar.gz
+
+DOWNLOADS_DIR=$(shell pwd)/downloads
+DOCFX_DIR=$(DOWNLOADS_DIR)/docfx
+DOCFX_ARCHIVE=$(shell pwd)/downloads/docfx.zip
+DOCFX_COMMAND=$(DOCFX_DIR)/docfx
+SIGNCODE_DIR=$(DOWNLOADS_DIR)/signcode
+SIGNCODE_ARCHIVE=$(shell pwd)/downloads/osslsigncode-2.1.0.tar.gz
+LOCAL_DEPENDENCIES=$(DOCFX_DIR) $(SIGNCODE_DIR)
+
+include ../base.mk
+
+$(DOCFX_DIR): $(DOCFX_ARCHIVE) $(DOCFX_COMMAND)
+	cd $(DOCFX_DIR) && unzip $(DOCFX_ARCHIVE)
+
+$(DOCFX_ARCHIVE):
+	mkdir -p $(DOWNLOADS_DIR)
+	curl --fail -L $(DOCFX_DOWNLOAD_URL) >$(DOCFX_ARCHIVE)
+
+# The docfx.exe that's provided in the current docfx distribution is a Mono
+# assembly, not a standalone executable. So we'll create a docfx command
+# to run it.
+$(DOCFX_COMMAND):
+	rm -rf $(DOCFX_DIR) && mkdir -p $(DOCFX_DIR)
+	echo >$(DOCFX_COMMAND) "#!/bin/bash"
+	echo >>$(DOCFX_COMMAND) "mono \$$(dirname \$$0)/docfx.exe \$$@"
+	chmod a+x $(DOCFX_COMMAND)
+
+$(SIGNCODE_DIR): $(SIGNCODE_ARCHIVE)
+	rm -rf $(SIGNCODE_DIR) && mkdir -p $(SIGNCODE_DIR)
+	cd $(SIGNCODE_DIR) && tar xfz $(SIGNCODE_ARCHIVE)
+
+$(SIGNCODE_ARCHIVE):
+	mkdir -p $(DOWNLOADS_DIR)
+	curl --fail -L $(SIGNCODE_DOWNLOAD_URL) >$(SIGNCODE_ARCHIVE)

--- a/dotnet5-release/README.md
+++ b/dotnet5-release/README.md
@@ -1,0 +1,8 @@
+# ldcircleci/dotnet5-release
+
+This is an Ubuntu 20.04 image with the following tools for LaunchDarkly .NET releases:
+
+* The .NET 5.0 SDK, which can build code for all .NET platforms except for Xamarin. The `PATH` includes the `dotnet` command.
+* The Mono SDK, a somewhat different distribution of the Linux .NET build tools; we don't need Mono for compiling our own code, but it is currently needed in order to run DocFX. The `PATH` also includes the `mono` command.
+* The [osslsigncode](https://github.com/mtrojnar/osslsigncode) tool, for Authenticode signing (Microsoft's `signtool.exe` isn't available for Linux, and Mono's `signtool` doesn't work properly with our certificate).
+* The [DocFX](https://dotnet.github.io/docfx/) tool for generating HTML documentation from in-code doc comments. The `PATH` includes the `docfx` command.


### PR DESCRIPTION
See description in `dotnet5-release/README.md`. We should be able to use this with our .NET projects that previously required a Windows CI host for releases. I've tested with the current development branch of Releaser to verify that the signing and documentation-building tools work.