### PR TITLE
add Releaser v1 compatibility image

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Docker images in this repository include:
 * [`ldcircleci/ld-c-sdk-ubuntu`](./ld-c-sdk-ubuntu)
 * [`ldcircleci/ld-xamarin-android-linux`](./ld-xamarin-android-linux)
 * [`ldcircleci/php-sdk-release`](./php-sdk-release)
+* [`ldcircleci/releaser-v1-compat`](./releaser-v1-compat)
 
 Older images we no longer use, but that can be found in the Git history of this repository if we ever need to reconstruct them:
 * `ldcircleci/ld-jdk7-jdk8`

--- a/releaser-v1-compat/Dockerfile
+++ b/releaser-v1-compat/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:20.04
+
+RUN groupadd -r releaser && useradd --no-log-init -rm -g releaser -s /bin/bash releaser
+
+# This time zone hack avoids a region prompt that some packages, like awscli, would otherwise try
+# to do interactively when they're installed. See:
+# https://unix.stackexchange.com/questions/433942/how-to-specify-extra-tz-info-for-apt-get-install-y-awscli
+RUN ln -snf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime && echo "America/Los_Angeles" >>/etc/timezone
+
+RUN apt -q update -y
+
+RUN apt -q install -y curl git
+
+# Go
+RUN curl -s https://dl.google.com/go/go1.15.5.linux-amd64.tar.gz | tar -xz -C /usr/local
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Java
+RUN apt -q install -y openjdk-8-jdk
+
+# Node
+RUN apt -q install -y nodejs npm
+
+# Python
+RUN apt -q install -y python3 python3-pip
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+RUN pip install twine
+
+# Ruby
+RUN apt -q install -y ruby
+RUN mkdir -p /home/releaser/.rubygems
+ENV GEM_HOME="/home/releaser/.rubygems/"
+ENV PATH="$PATH:/home/releaser/.rubygems/bin"
+
+# AWS
+RUN apt -q install -y awscli
+
+RUN chown -R releaser:releaser /home/releaser
+
+USER releaser

--- a/releaser-v1-compat/Makefile
+++ b/releaser-v1-compat/Makefile
@@ -1,0 +1,7 @@
+
+# This version should be incremented with every material change
+VERSION=1
+
+DOCKER_TAG_BASE="ldcircleci/releaser-v1-compat"
+
+include ../base.mk

--- a/releaser-v1-compat/README.md
+++ b/releaser-v1-compat/README.md
@@ -1,0 +1,3 @@
+# ldcircleci/releaser-v1-compat
+
+This Ubuntu image is used by the Releaser tool for releasing projects with old-style (v1) Releaser configurations that do not specify a Docker image. These used to be run directly on the Releaser host, so this image contains all of the same build tools that used to be installed on that host.


### PR DESCRIPTION
This will be used by Releaser v2 when building products that use the old-style v1 configuration. I was previously keeping this Dockerfile in the Releaser source repository (it's identical to the version that is on the v2 branch there, except for the image name), but there's no reason _not_ to publish it to DockerHub like our other build images, and publishing it from here means we don't have to wait for it to get built every time Releaser is built.

Releaser v1 didn't use Docker containers; the release scripts ran directly on the Releaser host (unless they were in CircleCI). Therefore, we had to make sure all the build tools we might ever need (Go, Java, etc.) were preinstalled on that host. This Docker image contains those same tools, so as to simulate the old environment.

The Releaser host also used to have some credentials preinstalled on it for accessing the various package managers, but those are _not_ in this image. They are obtained at runtime by Releaser on an as-needed basis.