### PR TITLE
Upgrade ubuntu to 20.04 in c-sdk & use latest cmake

### DIFF
--- a/ld-c-sdk-ubuntu/Dockerfile
+++ b/ld-c-sdk-ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 WORKDIR /home/circleci
 
@@ -10,13 +10,18 @@ WORKDIR /home/circleci
 # Documentation build: doxygen zip
 # Testing: valgrind
 
+# This is needed otherwise docker build will hang while Ubuntu asks us to select a timezone.
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get install -y \
   libcurl4-openssl-dev \
   libpcre3-dev \
   libhiredis-dev \
   build-essential \
-  cmake \
   doxygen \
   git \
   zip \
-  valgrind
+  valgrind \
+  wget
+
+RUN wget -qO- "https://cmake.org/files/v3.22/cmake-3.22.1-linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local

--- a/ld-c-sdk-ubuntu/Makefile
+++ b/ld-c-sdk-ubuntu/Makefile
@@ -1,6 +1,6 @@
 
 # This version should be incremented with every material change
-VERSION=2
+VERSION=3
 
 DOCKER_TAG_BASE="ldcircleci/ld-c-sdk-ubuntu"
 


### PR DESCRIPTION
Updates the base image from `18.04` -> `20.04` specifically to pull in a newer `glibc` &`valgrind`.

The motivation is to allow our CI usage of `valgrind` to work better, with less false-positives from the tool and more stability.

Additionally, I've updated cmake to a more recent version than can be found in the apt repositories.

This image is currently published as `ld-c-sdk-ubuntu:3`; the `latest` tag has not yet been pushed.


