### PR TITLE
update php-sdk-release image to use 7.4

### DIFF
--- a/php-sdk-release/Dockerfile
+++ b/php-sdk-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-cli
+FROM php:7.4-cli
 
 # zip may be needed as part of our documentation build process
 RUN apt-get -q update && apt-get -y install zip

--- a/php-sdk-release/Makefile
+++ b/php-sdk-release/Makefile
@@ -1,6 +1,6 @@
 
 # This version should be incremented with every material change
-VERSION=2
+VERSION=3
 
 DOCKER_TAG_BASE="ldcircleci/php-sdk-release"
 

--- a/php-sdk-release/README.md
+++ b/php-sdk-release/README.md
@@ -4,6 +4,6 @@ This Ubuntu image contains the PHP tools that are used in releasing the LaunchDa
 
 It provides the following:
 
-* A PHP 7.3 command-line distribution.
+* A PHP 7.4 command-line distribution.
 * Composer 2.x, available in the path as `composer`.
 * PhpDocumentor 3.x, available in the path as `phpdoc`.


### PR DESCRIPTION
We can bump it to 8.0 later this year after 7.4 is EOL.