### PR TITLE
new version of php-sdk-release image for PHP 8

### DIFF
--- a/php-sdk-release/Dockerfile
+++ b/php-sdk-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-cli
+FROM php:8.0-cli
 
 # zip may be needed as part of our documentation build process
 RUN apt-get -q update && apt-get -y install zip
@@ -13,7 +13,7 @@ RUN mkdir -p ${PHP_TOOLS_DIR}
 COPY downloads/composer ${PHP_TOOLS_DIR}
 COPY downloads/phpdoc ${PHP_TOOLS_DIR}
 
-# Here we're overriding CMD to a shell because the php:7.3-cli image sets CMD to the
+# Here we're overriding CMD to a shell because the php:8.0-cli image sets CMD to the
 # PHP interpreter-- which could be convenient if you wanted to just use the image to
 # run a single PHP command, but that's not really what our build image is for.
 CMD /bin/bash

--- a/php-sdk-release/Makefile
+++ b/php-sdk-release/Makefile
@@ -1,16 +1,16 @@
 
 # This version should be incremented with every material change
-VERSION=3
+VERSION=4
 
 DOCKER_TAG_BASE="ldcircleci/php-sdk-release"
 
-COMPOSER_VERSION=2.1.9
+COMPOSER_VERSION=2.4.2
 COMPOSER_DOWNLOAD_URL=https://getcomposer.org/download/$(COMPOSER_VERSION)/composer.phar
 # See https://getcomposer.org/download/
 COMPOSER_SHA256=4d00b70e146c17d663ad2f9a21ebb4c9d52b021b1ac15f648b4d371c04d648ba
 COMPOSER_ARCHIVE=$(shell pwd)/downloads/composer
 
-PHPDOCUMENTOR_VERSION=3.1.2
+PHPDOCUMENTOR_VERSION=3.3.1
 PHPDOCUMENTOR_DOWNLOAD_URL=https://github.com/phpDocumentor/phpDocumentor/releases/download/v$(PHPDOCUMENTOR_VERSION)/phpDocumentor.phar
 PHPDOCUMENTOR_ARCHIVE=$(shell pwd)/downloads/phpdoc
 

--- a/php-sdk-release/README.md
+++ b/php-sdk-release/README.md
@@ -4,6 +4,8 @@ This Ubuntu image contains the PHP tools that are used in releasing the LaunchDa
 
 It provides the following:
 
-* A PHP 7.4 command-line distribution.
+* A PHP 8.0 command-line distribution.
 * Composer 2.x, available in the path as `composer`.
 * PhpDocumentor 3.x, available in the path as `phpdoc`.
+
+For compatibility with older PHP versions, see older versions of this image.


### PR DESCRIPTION
This is for use in Releaser. The current Releaser PHP project template is still pinned to `ldcircleci/php-sdk-release:3`, so we can just override the image name in the release config file for the U2C branch of php-server-sdk-private.