### PR TITLE
Add curl to ld-c-sdk-ubuntu image

### DIFF
--- a/ld-c-sdk-ubuntu/Dockerfile
+++ b/ld-c-sdk-ubuntu/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /home/circleci
 # For cloning googletest code: git
 # Documentation build: doxygen zip
 # Testing: valgrind
+# Required by aws-cli authentication: curl
 
 # This is needed otherwise docker build will hang while Ubuntu asks us to select a timezone.
 ENV DEBIAN_FRONTEND=noninteractive
@@ -22,7 +23,8 @@ RUN apt-get update -y && apt-get install -y \
   git \
   zip \
   valgrind \
-  wget
+  wget \
+  curl
 
 RUN codename=$(cat /etc/os-release | grep UBUNTU_CODENAME | sed -e "s/^UBUNTU_CODENAME=//") \
     && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \

--- a/ld-c-sdk-ubuntu/Makefile
+++ b/ld-c-sdk-ubuntu/Makefile
@@ -1,6 +1,6 @@
 
 # This version should be incremented with every material change
-VERSION=4
+VERSION=5
 
 DOCKER_TAG_BASE="ldcircleci/ld-c-sdk-ubuntu"
 


### PR DESCRIPTION
When using a circleCI job with Releaser with this image, the job fails because `aws-cli` has a dependency on `curl`.

Therefore, this commit adds `curl` and bumps the image version to `5`.

