### PR TITLE
Update C container to grab cmake from Kitware apt repositories

### DIFF
--- a/ld-c-sdk-ubuntu/Dockerfile
+++ b/ld-c-sdk-ubuntu/Dockerfile
@@ -24,4 +24,11 @@ RUN apt-get update -y && apt-get install -y \
   valgrind \
   wget
 
-RUN wget -qO- "https://cmake.org/files/v3.22/cmake-3.22.1-linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local
+RUN codename=$(cat /etc/os-release | grep UBUNTU_CODENAME | sed -e "s/^UBUNTU_CODENAME=//") \
+    && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ ${codename} main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
+    && apt purge --auto-remove cmake \
+    && apt-get update -y \
+    && apt-get install -y cmake
+
+

--- a/ld-c-sdk-ubuntu/Makefile
+++ b/ld-c-sdk-ubuntu/Makefile
@@ -1,6 +1,6 @@
 
 # This version should be incremented with every material change
-VERSION=3
+VERSION=4
 
 DOCKER_TAG_BASE="ldcircleci/ld-c-sdk-ubuntu"
 


### PR DESCRIPTION
This changes how we obtain `cmake` in the `ld-c-sdk-ubuntu` image. 

Instead of using `wget` to download it from their website (the URL may not be stable, and it encodes the architecture), fetch it from Kitware's own repositories.

This ensures we always have the latest supported version for that Ubuntu release, without needing to manually maintain the URL.

