### PR TITLE
chore: mark repository as discontinued / being archived [SDK-2579]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 > [!WARNING]
 > **This repository is discontinued and is being archived.** The Docker images it produced are no
-> longer maintained or rebuilt. The SDK repositories that consumed these images now provide their
-> own build environments (for example, `ld-openapi` generates the API clients directly with
-> `actions/setup-java` instead of using `ldcircleci/openapi-release`). The image sources below
-> remain only for historical reference and may be reconstructed from this repository's Git history
-> if ever needed.
+> longer maintained or rebuilt. The SDK repositories that consumed these images must now provide
+> their own build environments. The image sources below remain only for historical reference and
+> may be reconstructed from this repository's Git history if ever needed.
 
 This project contains build scripts for Docker images used by LaunchDarkly SDK CI builds and releases. These Dockerfiles are publicly accessible because they're referenced in CircleCI configuration files within the open-source SDK repositories.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Docker images for LaunchDarkly SDK CI
 
+> [!WARNING]
+> **This repository is discontinued and is being archived.** The Docker images it produced are no
+> longer maintained or rebuilt. The SDK repositories that consumed these images now provide their
+> own build environments (for example, `ld-openapi` generates the API clients directly with
+> `actions/setup-java` instead of using `ldcircleci/openapi-release`). The image sources below
+> remain only for historical reference and may be reconstructed from this repository's Git history
+> if ever needed.
+
 This project contains build scripts for Docker images used by LaunchDarkly SDK CI builds and releases. These Dockerfiles are publicly accessible because they're referenced in CircleCI configuration files within the open-source SDK repositories.
 
 Despite the `ldcircleci/` prefix, these images could also be used in release processes that do not use a CI host.


### PR DESCRIPTION
Adds a warning banner to the README noting that this repository is discontinued and is being archived.

The Docker images here are no longer maintained or rebuilt. The last live consumer — `ld-openapi`'s CI use of `ldcircleci/openapi-release` — is being removed in [ld-openapi-private#299](https://github.com/launchdarkly/ld-openapi-private/pull/299), after which this repo can be archived (tracked via Terraform).

Jira: SDK-2579